### PR TITLE
Check if options argument is an object

### DIFF
--- a/google-maps.js
+++ b/google-maps.js
@@ -62,6 +62,8 @@ Template.googleMap.rendered = function() {
         throw new Meteor.Error("GoogleMaps - Missing argument: name");
       if ($.isEmptyObject(data.options))
         throw new Meteor.Error("GoogleMaps - Missing argument: options");
+      if (!(data.options instanceof Object))
+        throw new Meteor.Error("GoogleMaps - options argument is not an object");
       
       var canvas = self.$('.map-canvas').get(0);
 


### PR DESCRIPTION
This adds a check against a simple error I myself made:

```
{{> googleMap name="mapName" options="optionsOptions"}}
```

Currently this gives a cryptic exception:

```
Exception from Tracker afterFlush function: Cannot assign to read only property 'mapTypeId' of options
TypeError: Cannot assign to read only property 'mapTypeId' of options
```

After this pull request the exception is:

```
Exception from Tracker afterFlush function: Error: [GoogleMaps - options argument is not an object]
```
