### PR TITLE
Fixing array check in onDestroyed

### DIFF
--- a/google-maps.js
+++ b/google-maps.js
@@ -118,7 +118,7 @@ Template.googleMap.onRendered(function() {
 });
 
 Template.googleMap.onDestroyed(function() {
-  if (GoogleMaps[this._name]) {
+  if (GoogleMaps.maps[this._name]) {
     google.maps.event.clearInstanceListeners(GoogleMaps.maps[this._name].instance);
     delete GoogleMaps.maps[this._name];
   }


### PR DESCRIPTION
Just a small change;
Currently the onDestroyed stuff is never called, because the check is on the root GoogleMaps element, not the maps object within it.
