### PR TITLE
Make blaze dependency weak

### DIFF
--- a/google-maps.js
+++ b/google-maps.js
@@ -87,39 +87,41 @@ GoogleMaps = {
   }
 };
 
-Template.googleMap.onRendered(function() {
-  var self = this;
-  self.autorun(function(c) {
-    // if the api has loaded
-    if (GoogleMaps.loaded()) {
-      var data = Template.currentData();
+if (Package["templating"]) {
+  Template.googleMap.onRendered(function() {
+    var self = this;
+    self.autorun(function(c) {
+      // if the api has loaded
+      if (GoogleMaps.loaded()) {
+        var data = Template.currentData();
 
-      if (! data.options) {
-        return;
+        if (! data.options) {
+          return;
+        }
+        if (! data.name) {
+          throw new Meteor.Error("GoogleMaps - Missing argument: name");
+        }
+
+        self._name = data.name;
+
+        var canvas = self.$('.map-canvas').get(0);
+
+        GoogleMaps.create({
+          name: data.name,
+          type: data.type,
+          element: canvas,
+          options: data.options
+        });
+
+        c.stop();
       }
-      if (! data.name) {
-        throw new Meteor.Error("GoogleMaps - Missing argument: name");
-      }
+    });
+  });
 
-      self._name = data.name;
-
-      var canvas = self.$('.map-canvas').get(0);
-
-      GoogleMaps.create({
-        name: data.name,
-        type: data.type,
-        element: canvas,
-        options: data.options
-      });
-
-      c.stop();
+  Template.googleMap.onDestroyed(function() {
+    if (GoogleMaps.maps[this._name]) {
+      google.maps.event.clearInstanceListeners(GoogleMaps.maps[this._name].instance);
+      delete GoogleMaps.maps[this._name];
     }
   });
-});
-
-Template.googleMap.onDestroyed(function() {
-  if (GoogleMaps.maps[this._name]) {
-    google.maps.event.clearInstanceListeners(GoogleMaps.maps[this._name].instance);
-    delete GoogleMaps.maps[this._name];
-  }
-});
+}

--- a/package.js
+++ b/package.js
@@ -7,14 +7,14 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
-  api.use([
-    'reactive-var',
-    'underscore']);
+  api.use(['reactive-var', 'underscore']);
   api.use('templating', ['client', 'server'], { weak: true });
-  api.addFiles([
-    'google-maps.html',
-    'google-maps.js'], 'client');
+  api.addFiles('google-maps.js', 'client');
   api.export('GoogleMaps', 'client');
+
+  if (Package['templating']) {
+    api.addFiles('google-maps.html', 'client');
+  }
 });
 
 Package.onTest(function(api) {

--- a/package.js
+++ b/package.js
@@ -8,9 +8,9 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
   api.use([
-    'templating',
     'reactive-var',
     'underscore']);
+  api.use('templating', ['client', 'server'], { weak: true });
   api.addFiles([
     'google-maps.html',
     'google-maps.js'], 'client');


### PR DESCRIPTION
This PR makes blaze a weak dependency of this package, meaning that if you don't use blaze in your app, it won't pollute your bundle.

I'm struggling with the html template, meteor tells me this:

```
   While building package dburles:google-maps:
   error: No plugin known to handle file 'google-maps.html'. If you want this file to be a static
   asset, use addAssets instead of addFiles; eg, api.addAssets('google-maps.html', 'client').
```

How can I handle this?